### PR TITLE
Refactoring/logging events

### DIFF
--- a/models/__init__.py
+++ b/models/__init__.py
@@ -1,1 +1,9 @@
-from models.models import OBSCloudModel, MinionSettings, VmixPlayer, Registry, State, TimingEntry, orjson_dumps
+from models.models import (
+    OBSCloudModel,
+    MinionSettings,
+    VmixPlayer,
+    Registry,
+    State,
+    TimingEntry,
+    orjson_dumps,
+)

--- a/models/logging.py
+++ b/models/logging.py
@@ -1,0 +1,51 @@
+from collections import deque
+from datetime import datetime
+from enum import Enum
+from threading import RLock
+
+from pydantic.fields import PrivateAttr
+
+
+class LogLevel(Enum):
+    info = 1
+    warn = 2
+    error = 3
+
+
+class Log:
+    def __init__(self, level: LogLevel, type: str, message: str, error: Exception = None, extra: dict = None):
+        self.level: LogLevel = level
+        self.type: str = type
+        self.message: str = message
+        self.error: str = str(error) if error else None
+        self.timestamp: datetime = datetime.now()
+        self.extra: dict = extra
+
+    def dict(self):
+        return {
+            "level": self.level.name,
+            "type": self.type,
+            "message": self.message,
+            "error": self.error,
+            "timestamp": self.timestamp.isoformat(),
+            "extra": self.extra,
+        }
+
+
+class LogsStorage:
+    logs: deque[Log] = []
+    _lock = PrivateAttr()
+
+    def __init__(self):
+        self._lock = RLock()
+        self.logs = deque()
+
+    def append(self, log: Log):
+        with self._lock:
+            self.logs.append(log)
+            if len(self.logs) > 1000:  # TODO: Extract logs limit to config
+                self.logs.popleft()
+
+    def get(self, count: int):
+        with self._lock:
+            return self.logs[-count:]

--- a/models/logging.py
+++ b/models/logging.py
@@ -34,14 +34,13 @@ class Log:
 
 class LogsStorage:
     logs: deque[dict] = []
-    _lock = PrivateAttr()
+    _lock = None
 
     def __init__(self):
         self._lock = RLock()
         self.logs = deque()
 
     def append(self, log: Log):
-        print('Append log:', log)
         with self._lock:
             self.logs.append(log.dict())
             if len(self.logs) > 1000:  # TODO: Extract logs limit to config
@@ -49,5 +48,4 @@ class LogsStorage:
 
     def get(self, count: int) -> list[dict]:
         with self._lock:
-            print('self.logs', self.logs)
             return list(self.logs)[-count:]

--- a/models/logging.py
+++ b/models/logging.py
@@ -33,7 +33,7 @@ class Log:
 
 
 class LogsStorage:
-    logs: deque[Log] = []
+    logs: deque[dict] = []
     _lock = PrivateAttr()
 
     def __init__(self):
@@ -41,11 +41,13 @@ class LogsStorage:
         self.logs = deque()
 
     def append(self, log: Log):
+        print('Append log:', log)
         with self._lock:
-            self.logs.append(log)
+            self.logs.append(log.dict())
             if len(self.logs) > 1000:  # TODO: Extract logs limit to config
                 self.logs.popleft()
 
-    def get(self, count: int):
+    def get(self, count: int) -> list[dict]:
         with self._lock:
-            return self.logs[-count:]
+            print('self.logs', self.logs)
+            return list(self.logs)[-count:]

--- a/models/models.py
+++ b/models/models.py
@@ -159,6 +159,7 @@ class TimingEntry(BaseModel):
         json_loads = orjson.loads
         json_dumps = orjson_dumps
 
+
 class State:
     sleeping = "sleeping"
     initializing = "initializing"
@@ -207,14 +208,15 @@ class Registry(BaseModel):
             return super(Registry, self).__getattr__(item)
 
     def __setattr__(self, key, value):
-        if key in ("_lock", "_skipper", "infrastructure_lock"):
+        if key in ("_lock", "_skipper"):
             super(Registry, self).__setattr__(key, value)
         else:
             with self._lock:
                 if key == "server_status":
                     self._last_server_status = self.server_status
                 super(Registry, self).__setattr__(key, value)
-            self._skipper.event_sender.send_registry_change(self.dict())
+        if key in ("server_status", "infrastructure_lock"):
+            self._skipper.event_sender.send_registry_change({key: value})
 
     def list_langs(self):
         return list(self.minion_configs.keys())

--- a/models/models.py
+++ b/models/models.py
@@ -1,8 +1,6 @@
-import json
 from datetime import datetime, timedelta
 from threading import RLock
 from typing import List, Dict
-import re
 
 from pydantic import BaseModel, PrivateAttr
 from pydantic.schema import Optional

--- a/server/skipper.py
+++ b/server/skipper.py
@@ -464,7 +464,6 @@ class Skipper:
             command, details, lang = command["command"], command["details"], command["lang"]
 
             result = self.exec(command, details=details, lang=lang, environ=environ)
-            print(f"AFTER EXECUTION::: {command}")
             self.event_sender.send_log(
                 type=LogType.command_completed,
                 message=f"Command '{command}' execution successfully completed",
@@ -516,10 +515,10 @@ class Skipper:
                     langs = (
                         None  # None - means all langs
                         if (
-                                (not details)
-                                or ("langs" not in details)
-                                or (not isinstance(details["langs"], list))
-                                or (not all([isinstance(obj, str) for obj in details["langs"]]))
+                            (not details)
+                            or ("langs" not in details)
+                            or (not isinstance(details["langs"], list))
+                            or (not all([isinstance(obj, str) for obj in details["langs"]]))
                         )
                         else details["langs"]  # the code above validates details["langs"]
                     )
@@ -542,12 +541,12 @@ class Skipper:
                     return ExecutionStatus(True,
                                            serializable_object=orjson_dumps({"registry": self.skipper.registry.dict()}))
                 elif command in (
-                        "set stream settings",
-                        "set teamspeak offset",
-                        "set teamspeak volume",
-                        "set source volume",
-                        "set sidechain settings",
-                        "set transition settings",
+                    "set stream settings",
+                    "set teamspeak offset",
+                    "set teamspeak volume",
+                    "set source volume",
+                    "set sidechain settings",
+                    "set transition settings",
                 ):
                     return self.set_info(command=command, details=details, lang=lang, environ=environ)
                 elif command == "infrastructure lock":
@@ -728,10 +727,10 @@ class Skipper:
                 # details: {"ratio": ..., "release_time": ..., "threshold": ..., "output_gain": ...}
                 # all parameters are numeric
                 if (
-                        "ratio" not in details
-                        and "release_time" not in details
-                        and "threshold" not in details
-                        and "output_gain" not in details
+                    "ratio" not in details
+                    and "release_time" not in details
+                    and "threshold" not in details
+                    and "output_gain" not in details
                 ):
                     return ExecutionStatus(False, f"Invalid details provided for '{command}': {details}")
                 try:

--- a/server/skipper.py
+++ b/server/skipper.py
@@ -59,7 +59,7 @@ class Skipper:
                 except Exception as ex:
                     message = "Something happened while deploying minions"
                     self.skipper.event_sender.send_log(
-                        type=LogType.minion_error,
+                        type=LogType.minions_setup_error,
                         message=message,
                         error=ex
                     )
@@ -74,9 +74,9 @@ class Skipper:
                 except ConnectionError as ex:
                     message = "Something happened while creating Minion instances"
                     self.skipper.event_sender.send_log(
-                        type=LogType.minion_error,
+                        type=LogType.minions_setup_error,
                         message=message,
-                        error=ex
+                        error=ex,
                     )
                     # with self.skipper.registry_lock:
                     self.skipper.registry.revert_server_state()

--- a/server/skipper.py
+++ b/server/skipper.py
@@ -359,7 +359,7 @@ class Skipper:
         def send_log(self, type: LogType, message: str, error: Exception = None, extra: dict = None):
             try:
                 data = {
-                    "level": type.value[0],
+                    "level": type.value[0].name,
                     "type": type.value[1],
                     "message": message,
                     "error": str(error) if error else None,
@@ -367,9 +367,8 @@ class Skipper:
                     "extra": extra,
                 }
                 self.skipper.sio.emit("on_log", data=json.dumps(data), broadcast=True)
-            except:
-                # TODO: log unhandled exceptions anywhere
-                pass
+            except Exception as ex:
+                print(f"Sending log error: {ex}")
 
     class Command:
         """
@@ -465,7 +464,7 @@ class Skipper:
             command, details, lang = command["command"], command["details"], command["lang"]
 
             result = self.exec(command, details=details, lang=lang, environ=environ)
-
+            print(f"AFTER EXECUTION::: {command}")
             self.event_sender.send_log(
                 type=LogType.command_completed,
                 message=f"Command '{command}' execution successfully completed",

--- a/server/skipper.py
+++ b/server/skipper.py
@@ -198,7 +198,6 @@ class Skipper:
                     }
                 )
                 # TODO: log
-                raise ConnectionError(f"Connection error for ip {self.minion_ip} lang {self.lang}. Details:\n{ex}")
                 raise ConnectionError(f"{message}. Details:\n{ex}")
 
         def _register_event_handlers(self):
@@ -384,7 +383,7 @@ class Skipper:
             self.skipper: Skipper = skipper
 
         def send_registry_change(self, registry: dict):
-            self.skipper.sio.emit("on_registry_change", data=json.dumps(registry), broadcast=True)
+            self.skipper.sio.emit("on_registry_change", data=orjson_dumps(registry), broadcast=True)
 
         def send_log(self, type: LogType, message: str, error: Exception = None, extra: dict = None):
             try:
@@ -933,9 +932,7 @@ class Skipper:
                         new_registry_state = self.skipper.registry.json()
                         if self._last_registry_state != new_registry_state:
                             self._last_registry_state = new_registry_state
-                            self.skipper.sio.emit("on_registry_change",
-                                                  data=orjson_dumps({"registry": self.skipper.registry.dict()}),
-                                                  broadcast=True)
+                            self.skipper.event_sender.send_registry_change(self.skipper.registry.dict())
                 except Exception as ex:
                     print(f"E Skipper::BGWorker::track_registry_change(): "
                           f"Couldn't broadcast registry change. Details: {ex}")  # TODO: handle and log

--- a/server/skipper.py
+++ b/server/skipper.py
@@ -279,6 +279,9 @@ class Skipper:
                     )
 
                     entry.is_played = True
+                    skipper.event_sender.send_registry_change({
+                        "timing_list": skipper.registry.timing_list
+                    })
                     return status
 
                 return foo

--- a/util/__init__.py
+++ b/util/__init__.py
@@ -6,6 +6,7 @@ from util.util import (
     ServiceAddrStorage,
     DefaultDict,
     CallbackThread,
+    LogType,
 )
 from util.util import (
     async_aiohttp_get_all,

--- a/util/__init__.py
+++ b/util/__init__.py
@@ -6,7 +6,6 @@ from util.util import (
     ServiceAddrStorage,
     DefaultDict,
     CallbackThread,
-    LogType,
 )
 from util.util import (
     async_aiohttp_get_all,

--- a/util/util.py
+++ b/util/util.py
@@ -5,7 +5,6 @@ import re
 import sys
 import threading
 import time
-from enum import Enum
 from threading import Lock
 
 import aiohttp
@@ -478,17 +477,3 @@ class WebsocketResponse:
 
     def result(self):
         return self.response
-
-
-class LogLevel(Enum):
-    info = 1
-    warn = 2
-    error = 3
-
-
-class LogType(Enum):
-    command_started = (LogLevel.info, 'command_started')
-    command_completed = (LogLevel.info, 'command_completed')
-    skipper_error = (LogLevel.error, 'skipper_error')
-    minion_error = (LogLevel.error, 'minion_error')
-    minions_setup_error = (LogLevel.error, 'minion_setup_error')

--- a/util/util.py
+++ b/util/util.py
@@ -481,9 +481,9 @@ class WebsocketResponse:
 
 
 class LogLevel(Enum):
-    info = 'info'
-    warn = 'warn'
-    error = 'error'
+    info = 1
+    warn = 2
+    error = 3
 
 
 class LogType(Enum):

--- a/util/util.py
+++ b/util/util.py
@@ -487,7 +487,8 @@ class LogLevel(Enum):
 
 
 class LogType(Enum):
-    command_started = (LogLevel.info, 'Command Started')
-    command_completed = (LogLevel.info, 'Command Completed')
-    skipper_error = (LogLevel.error, 'Skipper Error')
-    minion_error = (LogLevel.error, 'Minion Error')
+    command_started = (LogLevel.info, 'command_started')
+    command_completed = (LogLevel.info, 'command_completed')
+    skipper_error = (LogLevel.error, 'skipper_error')
+    minion_error = (LogLevel.error, 'minion_error')
+    minions_setup_error = (LogLevel.error, 'minion_setup_error')

--- a/util/util.py
+++ b/util/util.py
@@ -1,12 +1,12 @@
 import asyncio
 import hashlib
+import json
 import re
 import sys
 import threading
-from threading import Lock
 import time
-import json
-from typing import List
+from enum import Enum
+from threading import Lock
 
 import aiohttp
 from asgiref import sync
@@ -19,7 +19,6 @@ def async_aiohttp_get_all(urls):
 
     async def get_all(urls):
         async with aiohttp.ClientSession() as session:
-
             async def fetch(url):
                 async with session.get(url) as response:
                     return Response(await response.text(), response.status)
@@ -37,7 +36,6 @@ def async_aiohttp_post_all(urls):
 
     async def get_all(urls):
         async with aiohttp.ClientSession() as session:
-
             async def fetch(url):
                 async with session.post(url) as response:
                     return Response(await response.text(), response.status)
@@ -55,7 +53,6 @@ def async_aiohttp_delete_all(urls):
 
     async def get_all(urls):
         async with aiohttp.ClientSession() as session:
-
             async def fetch(url):
                 async with session.delete(url) as response:
                     return Response(await response.text(), response.status)
@@ -73,7 +70,6 @@ def async_aiohttp_put_all(urls):
 
     async def get_all(urls):
         async with aiohttp.ClientSession() as session:
-
             async def fetch(url):
                 async with session.put(url) as response:
                     return Response(await response.text(), response.status)
@@ -110,7 +106,7 @@ def validate_media_play_params(name, use_file_num):
     return ExecutionStatus(status=True)
 
 
-def generate_file_md5(filename, blocksize=2**25):
+def generate_file_md5(filename, blocksize=2 ** 25):
     m = hashlib.md5()
     with open(filename, "rb") as f:
         while True:
@@ -482,3 +478,16 @@ class WebsocketResponse:
 
     def result(self):
         return self.response
+
+
+class LogLevel(Enum):
+    info = 'info'
+    warn = 'warn'
+    error = 'error'
+
+
+class LogType(Enum):
+    command_started = (LogLevel.info, 'Command Started')
+    command_completed = (LogLevel.info, 'Command Completed')
+    skipper_error = (LogLevel.error, 'Skipper Error')
+    minion_error = (LogLevel.error, 'Minion Error')

--- a/web_socket_docs.md
+++ b/web_socket_docs.md
@@ -645,3 +645,44 @@
 }
 ```
 ------------------------------------------------------------------------------
+###  - `get logs`
+ - **Description:** Returns a list of N last logs.
+ - **Parameters:**
+   - `count` - count of logs to get, 100 by default (optional parameter).
+ - **Returns:**
+```json
+{
+  "result": true/false,
+  "details": "... message ...",
+  "serializable_object": {
+    "logs": [
+      {
+        "level": "info" | "warn" | "error",
+        "type": "short_log_type_name",
+        "message": "... message ...",
+        "error": "... error message ..." | null,
+        "timestamp": "2017-08-02T12:15:00.000000",
+        "extra": {
+          "minion_ip": "if type == minion_error",
+          "minion_lang": "if type == minion_error", 
+          "command": "if type == command_completed or skipper_error",
+          "details": "if type == command_completed or skipper_error",
+          "lang": "if type == command_completed or skipper_error",
+          "ip": "if type == command_completed or skipper_error"
+        }
+      }
+    ]
+  }
+}
+```
+ - **Notes:**
+ - **Command example (json):**
+```json
+{
+  "command": "get logs",
+  "details": {
+    "count": 100
+  }
+}
+```
+------------------------------------------------------------------------------

--- a/web_socket_docs.md
+++ b/web_socket_docs.md
@@ -12,6 +12,28 @@
   "registry": models.Registry().dict()
 }
 ```
+
+###  - `on_log`
+ - **Description:** Point to receive all backend (skipper and any minions) logs.
+ - **Returns:**
+```json
+{
+  "level": "info" | "warn" | "error",
+  "type": "short_log_type_name",
+  "message": "... message ...",
+  "error": "... error message ..." | null,
+  "timestamp": "2017-08-02T12:15:00.000000",
+  "extra": {
+    "minion_ip": "if type == minion_error",
+    "minion_lang": "if type == minion_error", 
+    "command": "if type == command_completed or skipper_error",
+    "details": "if type == command_completed or skipper_error",
+    "lang": "if type == command_completed or skipper_error",
+    "ip": "if type == command_completed or skipper_error"
+  }
+}
+```
+
 ------------------------------------------------------------------------------
 
 # Commands

--- a/web_socket_docs.md
+++ b/web_socket_docs.md
@@ -18,18 +18,20 @@
  - **Returns:**
 ```json
 {
-  "level": "info" | "warn" | "error",
-  "type": "short_log_type_name",
-  "message": "... message ...",
-  "error": "... error message ..." | null,
-  "timestamp": "2017-08-02T12:15:00.000000",
-  "extra": {
-    "minion_ip": "if type == minion_error",
-    "minion_lang": "if type == minion_error", 
-    "command": "if type == command_completed or skipper_error",
-    "details": "if type == command_completed or skipper_error",
-    "lang": "if type == command_completed or skipper_error",
-    "ip": "if type == command_completed or skipper_error"
+  "log": {
+    "level": "info" | "warn" | "error",
+    "type": "short_log_type_name",
+    "message": "... message ...",
+    "error": "... error message ..." | null,
+    "timestamp": "2017-08-02T12:15:00.000000",
+    "extra": {
+      "minion_ip": "if type == minion_error",
+      "minion_lang": "if type == minion_error", 
+      "command": "if type == command_completed or skipper_error",
+      "details": "if type == command_completed or skipper_error",
+      "lang": "if type == command_completed or skipper_error",
+      "ip": "if type == command_completed or skipper_error"
+    }
   }
 }
 ```


### PR DESCRIPTION
Основное:
- Добавил класс `EventSender`. Теперь вся логика по отправке событий через сокеты будет в одном месте.
- Соответственно в `Registry` поменял прямой вызов ивента на вызов посредством этого класса
- Также добавил сюда метод на отправку любых логов

Отправка логов происходит на следующие события:
- `command_started` перед выполнением ПРОДОЛЖИТЕЛЬНОЙ команды (пока НЕ ЮЗАЕТСЯ, надо будет решить, на какие из команд стоит его повесить, какие предположительно будут самые длительные)
- `command_completed` после выполнения любой команды
- `skipper_error` если что-то пошло не так при выполнении команды (потом можно будет добавить его на любые ошибки во всех местах на стороне шкипера)
- `minion_error` если что-то не так на миньоне (сейчас если не получилось приконнектиться к миньону)
- `minion_setup_error` если что-то не так при инициализации миньонов (не уверен, на сколько это надо/правильно)